### PR TITLE
Fix 2 letter country code for Democratic Republic of the Congo

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -69,7 +69,7 @@ module.exports = [
 	new CountryData("Curaçao", "Dutch", "CW", "CUW"),
 	new CountryData("Cyprus", "Cypriot", "CY", "CYP"),
 	new CountryData("Czech Republic", "Czech", "CZ", "CZE"),
-	new CountryData("Democratic Republic of the Congo", "Congolese", "KP", "COD"),
+	new CountryData("Democratic Republic of the Congo", "Congolese", "CD", "COD"),
 	new CountryData("Denmark", "Danish", "DK", "DNK"),
 	new CountryData("Djibouti", "Djiboutian", "DJ", "DJI"),
 	new CountryData("Dominica", "Dominican", "DM", "DMA"),


### PR DESCRIPTION
Current code is set to North Korea