### PR TITLE
feat: add British Indian Ocean Territory flag

### DIFF
--- a/src/data/flagUrlByIso3.js
+++ b/src/data/flagUrlByIso3.js
@@ -105,6 +105,7 @@ module.exports = {
 	'IDN': createUrl('commons/9/9f/Flag_of_Indonesia.svg'),
 	'IMN': createUrl('commons/b/bc/Flag_of_the_Isle_of_Man.svg'),
 	'IND': createUrl('commons/4/41/Flag_of_India.svg'),
+	'IOT': createUrl("commons/6/65/Flag_of_the_Commissioner_of_the_British_Indian_Ocean_Territory.svg'),
 	'IRL': createUrl('commons/c/c0/Republic_of_Ireland_Flag.svg'),
 	'IRN': createUrl('commons/c/ca/Flag_of_Iran.svg'),
 	'IRQ': createUrl('commons/f/f6/Flag_of_Iraq.svg'),


### PR DESCRIPTION
Add url path for British Indian Ocean Territory (IOT). The code is listed on the [Wikipedia page for ISO-3166-1 alpha-3 codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).